### PR TITLE
refreshOrders added to Order component

### DIFF
--- a/src/components/Orders/Orders.jsx
+++ b/src/components/Orders/Orders.jsx
@@ -1,13 +1,15 @@
-import * as React from "react";
-import { useSelector } from "react-redux";
-import { styled } from "@mui/material/styles";
-import Table from "@mui/material/Table";
-import TableBody from "@mui/material/TableBody";
-import TableCell, { tableCellClasses } from "@mui/material/TableCell";
-import TableContainer from "@mui/material/TableContainer";
-import TableHead from "@mui/material/TableHead";
-import TableRow from "@mui/material/TableRow";
-import Paper from "@mui/material/Paper";
+import * as React from 'react';
+import { useSelector } from 'react-redux';
+import { styled } from '@mui/material/styles';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell, { tableCellClasses } from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+
+import refreshOrders from '../App/App';
 
 const StyledTableCell = styled(TableCell)(({ theme }) => ({
   [`&.${tableCellClasses.head}`]: {
@@ -20,17 +22,21 @@ const StyledTableCell = styled(TableCell)(({ theme }) => ({
 }));
 
 const StyledTableRow = styled(TableRow)(({ theme }) => ({
-  "&:nth-of-type(odd)": {
+  '&:nth-of-type(odd)': {
     backgroundColor: theme.palette.action.hover,
   },
   // hide last border
-  "&:last-child td, &:last-child th": {
+  '&:last-child td, &:last-child th': {
     border: 0,
   },
 }));
 
 export default function Orders() {
   const orders = useSelector((state) => state.orders);
+
+  // updates Order list on initial page load of Admin section.
+  refreshOrders();
+
   return (
     <TableContainer component={Paper}>
       <Table sx={{ minWidth: 700 }} aria-label="customized table">
@@ -43,8 +49,8 @@ export default function Orders() {
           </TableRow>
         </TableHead>
         <TableBody>
-          {orders.map((order) => (
-            <StyledTableRow >
+          {orders.map((order, id) => (
+            <StyledTableRow key={id}>
               <StyledTableCell component="th" scope="row">
                 {order.customer_name}
               </StyledTableCell>


### PR DESCRIPTION
- refreshOrder() added to Order component to refresh order list on initial page load of the Admin section. 
- Addition of id and key for the mapping of order list.

***Prettier auto syntax corrections on save.